### PR TITLE
Use the win10.choco file, not the git directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### 2. Install Boxstarter Package
 ```
 $Cred = Get-Credential $env:USERNAME
-Install-BoxstarterPackage -PackageName https://raw.githubusercontent.com/ZeroPointSecurity/RTOVMSetup/master/setup -Credential $Cred
+Install-BoxstarterPackage -PackageName https://raw.githubusercontent.com/ZeroPointSecurity/RTOVMSetup/master/setup/win10.choco -Credential $Cred
 ```
 
 ## Kali


### PR DESCRIPTION
The readme incorrectly points Boxstarter at the git directory, not the win10.choco install file.